### PR TITLE
Remove the deprecated git.io service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1783,7 +1783,6 @@
 | [Cutt.ly](https://cutt.ly/api-documentation/cuttly-links-api)                        | URL shortener service                                                              | `apiKey` | Yes   | Unknown |
 | [Drivet URL Shortener](https://wiki.drivet.xyz/en/url-shortener/add-links)           | Shorten a long URL easily and fast                                                 | No       | Yes   | Unknown |
 | [Free Url Shortener](https://ulvis.net/developer.html)                               | Free URL Shortener offers a powerful API to interact with other sites              | No       | Yes   | Unknown |
-| [Git.io](https://github.blog/2011-11-10-git-io-github-url-shortener/)                | Git.io URL shortener                                                               | No       | Yes   | Unknown |
 | [GoTiny](https://github.com/robvanbakel/gotiny-api)                                  | A lightweight URL shortener, focused on ease-of-use for the developer and end-user | No       | Yes   | Yes     |
 | [Kutt](https://docs.kutt.it/)                                                        | Free Modern URL Shortener                                                          | `apiKey` | Yes   | Yes     |
 | [Mgnet.me](http://mgnet.me/api.html)                                                 | Torrent URL shorten API                                                            | No       | Yes   | No      |


### PR DESCRIPTION
The git.io URL shortening service has been effectively retired. For more info see GitHub's [blog post][git-io-deprecation] about it.

[git-io-deprecation]: https://github.blog/changelog/2022-04-25-git-io-deprecation/

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] My addition is ordered alphabetically
- [ ] My submission has a useful description
- [ ] The description does not have more than 100 characters
- [ ] The description does not end with punctuation
- [ ] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
- [ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: <https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit>
