### PR TITLE
Removed AniAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ API | Description | Auth | HTTPS | CORS |
 ### Anime
 API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
-| [AniAPI](https://aniapi.com/docs/)| Anime discovery, streaming & syncing with trackers | `OAuth`| Yes | Yes |
 | [AniDB](https://wiki.anidb.net/HTTP_API_Definition) | Anime Database | `apiKey` | No| Yes |
 | [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs)| Anime discovery & tracking | `OAuth`| Yes | Unknown |
 | [AnimeChan](https://github.com/RocktimSaikia/anime-chan)| Anime quotes (over 10k+) | No | Yes | No|

--- a/db/resources.json
+++ b/db/resources.json
@@ -227,15 +227,6 @@
         "Category": "Animals"
     },
     {
-        "API": "AniAPI",
-        "Description": "Anime discovery, streaming & syncing with trackers",
-        "Auth": "OAuth",
-        "HTTPS": true,
-        "Cors": "yes",
-        "Link": "https://aniapi.com/docs/",
-        "Category": "Anime"
-    },
-    {
         "API": "AniDB",
         "Description": "Anime Database",
         "Auth": "apiKey",


### PR DESCRIPTION
Removed AniAPI. (#52)

The API domain `aniapi.com` is for sale and all the GitHub repositories are marked as public archives. It's save to assume that support for this API has stopped.